### PR TITLE
[update] クエリの実行回数を削減する(/record-views/allActive)

### DIFF
--- a/development/backend/src/api.js
+++ b/development/backend/src/api.js
@@ -432,6 +432,14 @@ const allActive = async (req, res) => {
   mylog(recordResult);
 
   const items = recordResult.map((record) => {
+    const lastAccessedAt = record.last_accessed_at;
+    const updatedAt = record.updated_at;
+
+    let isUnConfirmed = true;
+    if (lastAccessedAt && updatedAt) {
+      isUnConfirmed = Date.parse(lastAccessedAt) < Date.parse(updatedAt);
+    }
+
     return {
       recordId: record.record_id,
       title: record.title,
@@ -441,7 +449,7 @@ const allActive = async (req, res) => {
       createdByName: record.user_name,
       createAt: record.created_at,
       commentCount: record.comment_count,
-      isUnConfirmed: Date.parse(record.last_accessed_at) < Date.parse(record.updated_at),
+      isUnConfirmed: isUnConfirmed,
       thumbNailItemId: record.thumbnail_id,
       updatedAt: record.updated_at,
     }


### PR DESCRIPTION
## 概要
ループ内でのクエリの実行回数を削減する。

データベース側で紐づけられる情報は、クエリ実行時に予め紐づけて取得することで、アプリケーション側でのクエリ呼び出しを減らす。

ループ自体は残っているが、内部でSQLを実行していないので早くなるはず。